### PR TITLE
More Accurate Google Maps API Key Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,17 +354,17 @@ curl -u "USERNAME:ACCESS_KEY" https://api.browserstack.com/automate/plan.json
 
 ## [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
 
-Visit the following URL to check for validity:
-
+Issue the following command to ensure the key is `Active` and not restricted by the `Referer`:
 ```
-https://maps.googleapis.com/maps/api/directions/json?origin=Toronto&destination=Montreal&key=KEY_HERE
-https://maps.googleapis.com/maps/api/staticmap?center=40.714728,-73.998672&zoom=12&size=2500x2000&maptype=roadmap&key=KEY_HERE
+curl -H "referer: http://example.com" "https://maps.googleapis.com/maps/api/directions/json?origin=Stockholm&destination=Kalmar&key=KEY_HERE"
 ```
 More Information available here-
 
 https://medium.com/@ozguralp/unauthorized-google-maps-api-key-usage-cases-and-why-you-need-to-care-1ccb28bf21e
 
 https://github.com/ozguralp/gmapsapiscanner/
+
+https://developers.google.com/maps/api-key-best-practices
 
 ## [Google Recaptcha key](https://developers.google.com/recaptcha/docs/verify)
 


### PR DESCRIPTION
Hi team,

I've noticed the current method for testing Google Maps API keys is inaccurate as it doesn't show if the key is inactive or if the key is restricted by the `Referer` header.

We can issue the following command to confirm if the keys are indeed active and not restricted by the `Referer` header:

`curl -H "referer: http://example.com" "https://maps.googleapis.com/maps/api/directions/json?origin=Stockholm&destination=Kalmar&key=KEY_HERE"`

Different types of responses:

**Vulnerable**: `Key is valid & active with no restrictions`:
```
<long snippet>
         "warnings" : [],
         "waypoint_order" : []
      }
   ],
   "status" : "OK"
}
```

**Not Vulnerable**: `Key is valid & active but restricted by Referer`:
```
{
   "error_message" : "API keys with referer restrictions cannot be used with this API.",
   "routes" : [],
   "status" : "REQUEST_DENIED"
}
```

**Not Vulnerable**: `Key is valid, but not active`:
```
{
   "error_message" : "This API project is not authorized to use this API.",
   "routes" : [],
   "status" : "REQUEST_DENIED"
}
```

**Not Vulnerable**: `Key is invalid`:
```
{
   "error_message" : "The provided API key is invalid.",
   "routes" : [],
   "status" : "REQUEST_DENIED"
}
```

More information about different ways the keys can be restricted:
https://developers.google.com/maps/api-key-best-practices

Thank you,
\- mqt
