### PR TITLE
Add Calendly API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ KeyHacks shows ways in which particular API keys found on a Bug Bounty Program c
 - [Branch.io Key and Secret](#BranchIO-Key-and-Secret)
 - [BrowserStack Access Key](#BrowserStack-Access-Key)
 - [Buildkite Access token](#Buildkite-Access-token)
+- [Calendly API Key](#Calendly-API-Key)
 - [CircleCI Access Token](#CircleCI-Access-Token)
 - [DataDog API key](#DataDog-API-key)
 - [Deviant Art Access Token](#Deviant-Art-Access-Token)
@@ -625,6 +626,20 @@ Get all collections for a specific project:
 ```
 curl "https://api.keen.io/3.0/projects/PROJECT_ID/events?api_key=READ_KEY"
 ```
+
+## [Calendly API Key](https://developer.calendly.com/docs/)
+
+Get user information:
+
+````
+curl --header "X-TOKEN: <your_token>" https://calendly.com/api/v1/users/me
+````
+
+List Webhook Subscriptions:
+
+````
+curl --header "X-TOKEN: <your_token>" https://calendly.com/api/v1/hooks
+````
 
 # Contributing
 


### PR DESCRIPTION
Added Calendly API Key

Docs: https://developer.calendly.com/docs/

Impact: Obtaining user information, acquiring and deleting webhook subscriptions.