### PR TITLE
Adding GitLab Runner Registration Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ KeyHacks shows ways in which particular API keys found on a Bug Bounty Program c
 - [GitHub private SSH key](#GitHub-private-SSH-key)
 - [Github Token](#Github-Token)
 - [Gitlab personal access token](#Gitlab-personal-access-token)
+- [GitLab runner registration token](#Gitlab-runner-registration-token)
 - [Google Cloud Service Account credentials](#Google-Cloud-Service-Account-credentials)
 - [Google Maps API key](#Google-Maps-API-key)
 - [Google Recaptcha key](#Google-Recaptcha-key)
@@ -612,6 +613,22 @@ curl -i -X GET 'https://graph.facebook.com/v8.0/me/accounts?access_token={access
 ## [Gitlab personal access token](https://docs.gitlab.com/ee/api/README.html#personal-access-tokens)
 ```
 curl "https://gitlab.example.com/api/v4/projects?private_token=<your_access_token>"
+```
+
+## [GitLab runner registration token](https://docs.gitlab.com/runner/register/)
+```
+docker run --rm gitlab/gitlab-runner register \
+  --non-interactive \
+  --executor "docker" \
+  --docker-image alpine:latest \
+  --url "https://gitlab.com/" \
+  --registration-token "PROJECT_REGISTRATION_TOKEN" \
+  --description "keyhacks-test" \
+  --maintenance-note "Testing token with keyhacks" \
+  --tag-list "docker,aws" \
+  --run-untagged="true" \
+  --locked="false" \
+  --access-level="not_protected"
 ```
 
 ## [Paypal client id and secret key](https://developer.paypal.com/docs/api/get-an-access-token-curl/)


### PR DESCRIPTION
Example output for good token:
```
docker run --rm gitlab/gitlab-runner register \
  --non-interactive \
  --executor "docker" \
  --docker-image alpine:latest \
  --url "https://gitlab.com/" \
  --registration-token "GR13489413dcjcQjtGxUf2jkzQM9j" \
  --description "keyhacks-test" \
  --maintenance-note "Testing token with keyhacks" \
  --tag-list "docker,aws" \
  --run-untagged="true" \
  --locked="false" \
  --access-level="not_protected"
Runtime platform                                    arch=amd64 os=linux pid=7 revision=32fc1585 version=15.2.1
Running in system-mode.                            
                                                   
Registering runner... succeeded                     runner=GR13489413dcjcQjt
Runner registered successfully. Feel free to start it, but if it's running already the config should be automatically reloaded!
 
Configuration (with the authentication token) was saved in "/etc/gitlab-runner/config.toml" 
```
Example output for bad token (I just deleted the runner and reset the token):
```
docker run --rm gitlab/gitlab-runner register \
  --non-interactive \
  --executor "docker" \
  --docker-image alpine:latest \
  --url "https://gitlab.com/" \
  --registration-token "GR13489413dcjcQjtGxUf2jkzQM9j" \
  --description "keyhacks-test" \
  --maintenance-note "Testing token with keyhacks" \
  --tag-list "docker,aws" \
  --run-untagged="true" \
  --locked="false" \
  --access-level="not_protected"
Runtime platform                                    arch=amd64 os=linux pid=7 revision=32fc1585 version=15.2.1
Running in system-mode.                            
                                                   
ERROR: Registering runner... forbidden (check registration token)  runner=GR13489413dcjcQjt
PANIC: Failed to register the runner.  
```