### PR TITLE
fix: changed UserID to Me in Instagram's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ curl -H "Authorization: Bearer <ACCESS_TOKEN>" https://api.spotify.com/v1/me
 ## [Instagram Basic Display API Access Token](https://developers.facebook.com/docs/instagram-basic-display-api/getting-started)
 E.g.: IGQVJ...
 ```
-curl -X GET 'https://graph.instagram.com/{user-id}?fields=id,username&access_token={access-token}'
+curl -X GET 'https://graph.instagram.com/me?fields=id,username&access_token={access-token}'
 ```
 
 ## [Instagram Graph API Access Token](https://developers.facebook.com/docs/instagram-api/getting-started)


### PR DESCRIPTION
Hello, KeyHacks Team! Hope you're doing well!

Reading Instagram's API documentation I noticed it's not necessary to pass the UserID we can use the Me parameter instead of

Example:
```
curl -X GET \
  'https://graph.instagram.com/me?fields=id,username&access_token=IGQVJ...'
```

Documentation URL: https://developers.facebook.com/docs/instagram-basic-display-api/getting-started#etapa-4--autenticar-o-usu-rio-de-teste