### PR TITLE
Use the access-token endpoint for buildkite

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ https://api-ssl.bitly.com/v3/shorten?access_token=ACCESS_TOKEN&longUrl=https://w
 ## [Buildkite Access token](https://buildkite.com/docs/apis/rest-api)
 ```
 curl -H "Authorization: Bearer ACCESS_TOKEN" \
-https://api.buildkite.com/v2/user
+https://api.buildkite.com/v2/access-token
 ```
 
 ## [ButterCMS-API-Key](https://buttercms.com/docs/api/#authentication)


### PR DESCRIPTION
Its preferable to use the access-token endpoint for buildkite as the /user endpoint will fail if the token does not have the `read_user` scope.

https://buildkite.com/docs/apis/rest-api/access-token