### PR TITLE
Update to Shodan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ curl -X POST https://api.helpscout.net/v2/oauth2/token \
 
 ## [Shodan Api Key](https://developer.shodan.io/api/requirements)
 ```
-curl "https://api.shodan.io/shodan/host/8.8.8.8?key=TOKEN_HERE"
+curl -X GET "https://api.shodan.io/notifier?key={YOUR_API_KEY}"
 ```
 
 


### PR DESCRIPTION
The `/notifier` Shodan API endpoint discloses the email address attached to the API key thereby allowing the tester to verify if the Shodan API key belongs to a program or company under pentest.

For instance is the response to the request is;

```
{
    "matches": [
        {
            "description": null,
            "args": {
                "to": "example@example.com"
            },
            "provider": "email",
            "id": "default"
        },
        ...
    ],
    "total": 2
}
```

The tester can make a report to example site with proof the API key belongs to one of their employees/staff.

